### PR TITLE
Use Neon serverless HTTP driver by default; gate background workers w…

### DIFF
--- a/backend/nodemon.json
+++ b/backend/nodemon.json
@@ -4,7 +4,9 @@
   "ignore": ["src/**/*.spec.ts", "src/**/*.test.ts"],
   "exec": "ts-node --transpile-only src/index.ts",
   "env": {
-    "NODE_ENV": "development"
+    "NODE_ENV": "development",
+    "ENABLE_BACKGROUND_JOBS": "false",
+    "USE_NODE_PG": "false"
   },
   "delay": "1000",
   "legacyWatch": true,

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
   "description": "",
   "dependencies": {
     "@clerk/backend": "^2.3.1",
+    "@neondatabase/serverless": "^1.0.1",
     "@sentry/node": "^9.32.0",
     "@types/axios": "^0.14.4",
     "axios": "^1.10.0",
@@ -33,6 +34,7 @@
     "bullmq": "^5.56.0",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
+    "drizzle-kit": "^0.27.1",
     "drizzle-orm": "^0.44.2",
     "express": "^5.1.0",
     "express-winston": "^4.2.0",
@@ -43,13 +45,12 @@
     "openai": "^5.8.2",
     "pg": "^8.16.3",
     "prom-client": "^15.1.3",
+    "stripe": "^18.3.0",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
     "winston": "^3.17.0",
     "xml2js": "^0.6.2",
-    "zod": "^3.25.67",
-    "drizzle-kit": "^0.27.1",
-    "stripe": "^18.3.0"
+    "zod": "^3.25.67"
   },
   "devDependencies": {
     "@types/bcryptjs": "^3.0.0",

--- a/backend/src/db/client.ts
+++ b/backend/src/db/client.ts
@@ -1,9 +1,40 @@
-import { drizzle } from 'drizzle-orm/node-postgres';
+import { drizzle as drizzleNode } from 'drizzle-orm/node-postgres';
+import { drizzle as drizzleHTTP } from 'drizzle-orm/neon-http';
 import { Pool } from 'pg';
 import * as schema from './schema';
 
-const pool = new Pool({
-  connectionString: process.env.NEON_DATABASE_URL,
-});
+/**
+ * Use Neon serverless HTTP driver by default in development to avoid long-lived TCP connections
+ * that keep compute hot. Fallback to node-postgres pool when explicitly requested.
+ */
+const useNodePg = process.env.USE_NODE_PG === 'true';
 
-export const db = drizzle(pool, { schema });
+if (!process.env.NEON_DATABASE_URL && process.env.DATABASE_URL) {
+  process.env.NEON_DATABASE_URL = process.env.DATABASE_URL;
+}
+
+if (!process.env.NEON_DATABASE_URL) {
+  throw new Error('NEON_DATABASE_URL is not set');
+}
+
+let db: ReturnType<typeof drizzleNode> | ReturnType<typeof drizzleHTTP>;
+
+if (useNodePg) {
+  // Node pg with conservative pool settings for Neon
+  const pool = new Pool({
+    connectionString: process.env.NEON_DATABASE_URL,
+    max: Number(process.env.PG_POOL_MAX || 1),
+    min: 0,
+    idleTimeoutMillis: Number(process.env.PG_IDLE_TIMEOUT_MS || 1000 * 5),
+    ssl: process.env.PG_SSL === 'false' ? false : { rejectUnauthorized: false },
+  });
+  db = drizzleNode(pool, { schema });
+} else {
+  // HTTP driver (no pooling) keeps Neon compute cold between requests
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { neon } = require('@neondatabase/serverless');
+  const sql = neon(process.env.NEON_DATABASE_URL);
+  db = drizzleHTTP(sql, { schema });
+}
+
+export { db };

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -32,9 +32,16 @@ import {
 } from "./middleware/rateLimit";
 
 // Import workers to start background job processing
-import "./utils/sitemapWorker";
-import "./utils/analysisWorker";
-import "./utils/eventProcessor";
+// Conditionally start background workers (can be disabled in development)
+const enableBackgroundJobs = process.env.ENABLE_BACKGROUND_JOBS === "true";
+if (enableBackgroundJobs) {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require("./utils/sitemapWorker");
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require("./utils/analysisWorker");
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require("./utils/eventProcessor");
+}
 
 // Sentry initialization
 let sentryInitialized = false;

--- a/env.example
+++ b/env.example
@@ -1,5 +1,11 @@
 # Database
+# Prefer NEON_DATABASE_URL. In development we default to Neon HTTP driver to reduce compute usage.
+NEON_DATABASE_URL=postgresql://<user>:<password>@<neon-host>:<port>/<db>
 DATABASE_URL=postgresql://<user>:<password>@<neon-host>:<port>/<db>
+PG_POOL_MAX=1
+PG_IDLE_TIMEOUT_MS=5000
+PG_SSL=true
+USE_NODE_PG=false
 POSTGRES_DB=llm_optimizer_dev
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres_password
@@ -11,7 +17,8 @@ REDIS_URL=redis://<your-ec2-redis-host>:6379
 
 # Backend
 NODE_ENV=development
-PORT=3001
+BACKEND_PORT=3001
+ENABLE_BACKGROUND_JOBS=false
 JWT_SECRET=your-super-secret-jwt-key-change-in-production
 CORS_ORIGIN=http://localhost:3000
 


### PR DESCRIPTION
…ith ENABLE_BACKGROUND_JOBS; add env defaults and nodemon dev flags to minimize Neon compute in dev and prod