### PR TITLE
Implement score caching and site metrics updates

### DIFF
--- a/backend/drizzle/0019_powerful_tempest.sql
+++ b/backend/drizzle/0019_powerful_tempest.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "pages" ADD COLUMN "page_score" double precision;--> statement-breakpoint
+ALTER TABLE "pages" ADD COLUMN "last_score_update" timestamp;--> statement-breakpoint
+ALTER TABLE "sites" ADD COLUMN "average_llm_score" double precision;--> statement-breakpoint
+ALTER TABLE "sites" ADD COLUMN "total_pages" integer DEFAULT 0;--> statement-breakpoint
+ALTER TABLE "sites" ADD COLUMN "pages_with_scores" integer DEFAULT 0;--> statement-breakpoint
+ALTER TABLE "sites" ADD COLUMN "last_metrics_update" timestamp;

--- a/backend/drizzle/meta/0019_snapshot.json
+++ b/backend/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,1427 @@
+{
+  "id": "c51014a2-d368-4a56-998a-f2c72e6da62b",
+  "prevId": "547f9aed-3561-40c5-ae59-c5467e66b69a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.content_analysis": {
+      "name": "content_analysis",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overall_score": {
+          "name": "overall_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analyzed_at": {
+          "name": "analyzed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "llm_model_used": {
+          "name": "llm_model_used",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_summary": {
+          "name": "page_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis_summary": {
+          "name": "analysis_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_clarity": {
+          "name": "content_clarity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "content_structure": {
+          "name": "content_structure",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "content_completeness": {
+          "name": "content_completeness",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "title_optimization": {
+          "name": "title_optimization",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "heading_structure": {
+          "name": "heading_structure",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "schema_markup": {
+          "name": "schema_markup",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "primary_keywords": {
+          "name": "primary_keywords",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "long_tail_keywords": {
+          "name": "long_tail_keywords",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "keyword_density": {
+          "name": "keyword_density",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "semantic_keywords": {
+          "name": "semantic_keywords",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "definitions_present": {
+          "name": "definitions_present",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "faqs_present": {
+          "name": "faqs_present",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "structured_data": {
+          "name": "structured_data",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "citation_friendly": {
+          "name": "citation_friendly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "topic_coverage": {
+          "name": "topic_coverage",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "answerable_questions": {
+          "name": "answerable_questions",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "analysis_version": {
+          "name": "analysis_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1.0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "content_analysis_page_id_pages_id_fk": {
+          "name": "content_analysis_page_id_pages_id_fk",
+          "tableFrom": "content_analysis",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_deployments": {
+      "name": "content_deployments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_type": {
+          "name": "section_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_score": {
+          "name": "previous_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_score": {
+          "name": "new_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score_improvement": {
+          "name": "score_improvement",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployed_content": {
+          "name": "deployed_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployed_by": {
+          "name": "deployed_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployed_at": {
+          "name": "deployed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "content_deployments_page_id_pages_id_fk": {
+          "name": "content_deployments_page_id_pages_id_fk",
+          "tableFrom": "content_deployments",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_ratings": {
+      "name": "content_ratings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_result_id": {
+          "name": "analysis_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_type": {
+          "name": "section_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_score": {
+          "name": "current_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "previous_score": {
+          "name": "previous_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "improvement_count": {
+          "name": "improvement_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_improved_at": {
+          "name": "last_improved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "content_ratings_page_id_pages_id_fk": {
+          "name": "content_ratings_page_id_pages_id_fk",
+          "tableFrom": "content_ratings",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "content_ratings_analysis_result_id_content_analysis_id_fk": {
+          "name": "content_ratings_analysis_result_id_content_analysis_id_fk",
+          "tableFrom": "content_ratings",
+          "tableTo": "content_analysis",
+          "columnsFrom": [
+            "analysis_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_recommendations": {
+      "name": "content_recommendations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_result_id": {
+          "name": "analysis_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_type": {
+          "name": "section_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommendations": {
+          "name": "recommendations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'medium'"
+        },
+        "estimated_impact": {
+          "name": "estimated_impact",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "content_recommendations_page_id_pages_id_fk": {
+          "name": "content_recommendations_page_id_pages_id_fk",
+          "tableFrom": "content_recommendations",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "content_recommendations_analysis_result_id_content_analysis_id_fk": {
+          "name": "content_recommendations_analysis_result_id_content_analysis_id_fk",
+          "tableFrom": "content_recommendations",
+          "tableTo": "content_analysis",
+          "columnsFrom": [
+            "analysis_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_suggestions": {
+      "name": "content_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestions": {
+          "name": "suggestions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_context": {
+          "name": "request_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "content_suggestions_page_id_pages_id_fk": {
+          "name": "content_suggestions_page_id_pages_id_fk",
+          "tableFrom": "content_suggestions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.leads": {
+      "name": "leads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'tools'"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_analytics": {
+      "name": "page_analytics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visit_date": {
+          "name": "visit_date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_views": {
+          "name": "page_views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "unique_visitors": {
+          "name": "unique_visitors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "bounce_rate": {
+          "name": "bounce_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_session_duration": {
+          "name": "avg_session_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "load_time_ms": {
+          "name": "load_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_injected": {
+          "name": "content_injected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "content_types_injected": {
+          "name": "content_types_injected",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "page_analytics_site_id_sites_id_fk": {
+          "name": "page_analytics_site_id_sites_id_fk",
+          "tableFrom": "page_analytics",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_content": {
+      "name": "page_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_content": {
+          "name": "original_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "optimized_content": {
+          "name": "optimized_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_context": {
+          "name": "generation_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployed_at": {
+          "name": "deployed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployed_by": {
+          "name": "deployed_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "page_content_page_id_pages_id_fk": {
+          "name": "page_content_page_id_pages_id_fk",
+          "tableFrom": "page_content",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pages": {
+      "name": "pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_snapshot": {
+          "name": "content_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_scanned_at": {
+          "name": "last_scanned_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_analysis_at": {
+          "name": "last_analysis_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "llm_readiness_score": {
+          "name": "llm_readiness_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_score": {
+          "name": "page_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_score_update": {
+          "name": "last_score_update",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pages_site_id_sites_id_fk": {
+          "name": "pages_site_id_sites_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sites": {
+      "name": "sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tracker_id": {
+          "name": "tracker_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "average_llm_score": {
+          "name": "average_llm_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_pages": {
+          "name": "total_pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "pages_with_scores": {
+          "name": "pages_with_scores",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_metrics_update": {
+          "name": "last_metrics_update",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sites_url_unique": {
+          "name": "sites_url_unique",
+          "columns": [
+            {
+              "expression": "url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sites\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sites_user_id_users_id_fk": {
+          "name": "sites_user_id_users_id_fk",
+          "tableFrom": "sites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sites_tracker_id_unique": {
+          "name": "sites_tracker_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tracker_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tracker_data": {
+      "name": "tracker_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "site_id": {
+          "name": "site_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anonymous_user_id": {
+          "name": "anonymous_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referrer": {
+          "name": "referrer",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tracker_data_site_id_sites_id_fk": {
+          "name": "tracker_data_site_id_sites_id_fk",
+          "tableFrom": "tracker_data",
+          "tableTo": "sites",
+          "columnsFrom": [
+            "site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_subscriptions": {
+      "name": "user_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_type": {
+          "name": "subscription_type",
+          "type": "subscription_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'free'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_subscriptions_user_id_users_id_fk": {
+          "name": "user_subscriptions_user_id_users_id_fk",
+          "tableFrom": "user_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.subscription_type": {
+      "name": "subscription_type",
+      "schema": "public",
+      "values": [
+        "free",
+        "pro",
+        "enterprise"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1756241256062,
       "tag": "0018_fuzzy_prima",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1757053466276,
+      "tag": "0019_powerful_tempest",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio --port 4983",
     "db:seed": "ts-node --transpile-only src/db/seed.ts",
+    "populate-scores": "ts-node --transpile-only src/scripts/populateInitialScores.ts",
     "lint": "eslint src --ext .ts,.tsx --fix",
     "type-check": "tsc --noEmit",
     "test": "jest",

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -37,6 +37,11 @@ export const sites = pgTable("sites", {
   trackerId: uuid("tracker_id").notNull().unique(),
   status: varchar("status", { length: 32 }).notNull(),
   settings: jsonb("settings").default({}),
+  // Cached metrics for performance
+  averageLLMScore: doublePrecision("average_llm_score"), // Cached average of all page scores
+  totalPages: integer("total_pages").default(0), // Count of pages for faster calculations
+  pagesWithScores: integer("pages_with_scores").default(0), // Count of analyzed pages
+  lastMetricsUpdate: timestamp("last_metrics_update"), // When metrics were last calculated
   deletedAt: timestamp("deleted_at"),
   createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at").defaultNow(),
@@ -55,7 +60,9 @@ export const pages = pgTable("pages", {
   contentSnapshot: text("content_snapshot"),
   lastScannedAt: timestamp("last_scanned_at"),
   lastAnalysisAt: timestamp("last_analysis_at"),
-  llmReadinessScore: doublePrecision("llm_readiness_score"),
+  llmReadinessScore: doublePrecision("llm_readiness_score"), // Legacy field for compatibility
+  pageScore: doublePrecision("page_score"), // Cached overall score (0-100) from section ratings
+  lastScoreUpdate: timestamp("last_score_update"), // When score was last calculated
   createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at").defaultNow(),
 });

--- a/backend/src/scripts/populateInitialScores.ts
+++ b/backend/src/scripts/populateInitialScores.ts
@@ -1,0 +1,146 @@
+#!/usr/bin/env tsx
+
+/**
+ * Script to populate initial cached scores for existing pages
+ * This should be run after applying the database migration
+ * 
+ * Usage: npm run populate-scores
+ */
+
+import { db } from '../db/client';
+import { pages, sites } from '../db/schema';
+import { ScoreUpdateService } from '../services/scoreUpdateService';
+import { sql } from 'drizzle-orm';
+
+async function populateInitialScores() {
+  console.log('🚀 Starting initial score population...');
+  
+  try {
+    // Get all sites that are not deleted
+    const allSites = await db.select({ 
+      id: sites.id, 
+      name: sites.name,
+      url: sites.url 
+    })
+    .from(sites)
+    .where(sql`${sites.deletedAt} IS NULL`);
+
+    console.log(`📊 Found ${allSites.length} active sites`);
+
+    let totalPagesProcessed = 0;
+    let totalPagesWithScores = 0;
+    let totalSitesProcessed = 0;
+
+    for (const site of allSites) {
+      console.log(`\n🔄 Processing site: ${site.name} (${site.url})`);
+      
+      // Get all pages for this site
+      const sitePages = await db.select({ 
+        id: pages.id,
+        url: pages.url,
+        llmReadinessScore: pages.llmReadinessScore,
+        pageScore: pages.pageScore
+      })
+      .from(pages)
+      .where(sql`${pages.siteId} = ${site.id}`);
+
+      console.log(`  📄 Found ${sitePages.length} pages`);
+
+      let sitePagesWithScores = 0;
+
+      // Process each page
+      for (const page of sitePages) {
+        totalPagesProcessed++;
+        
+        // Skip if page already has a cached score
+        if (page.pageScore != null) {
+          console.log(`  ✅ Page ${page.url} already has cached score: ${page.pageScore}%`);
+          sitePagesWithScores++;
+          totalPagesWithScores++;
+          continue;
+        }
+
+        // Try to update the score from section ratings
+        const newScore = await ScoreUpdateService.updatePageScore(page.id);
+        
+        if (newScore !== null) {
+          console.log(`  ✅ Updated page ${page.url}: ${newScore}%`);
+          sitePagesWithScores++;
+          totalPagesWithScores++;
+        } else if (page.llmReadinessScore != null && page.llmReadinessScore > 0) {
+          // Fallback: use legacy score as cached score
+          await db.update(pages)
+            .set({
+              pageScore: page.llmReadinessScore,
+              lastScoreUpdate: new Date()
+            })
+            .where(sql`${pages.id} = ${page.id}`);
+          
+          console.log(`  📋 Used legacy score for ${page.url}: ${page.llmReadinessScore}%`);
+          sitePagesWithScores++;
+          totalPagesWithScores++;
+        } else {
+          console.log(`  ⚠️ No score available for ${page.url}`);
+        }
+      }
+
+      // Update site metrics after processing all pages
+      if (sitePagesWithScores > 0) {
+        await ScoreUpdateService.updateSiteMetrics(site.id);
+        console.log(`  📊 Updated site metrics (${sitePagesWithScores}/${sitePages.length} pages with scores)`);
+      }
+
+      totalSitesProcessed++;
+    }
+
+    console.log('\n🎉 Initial score population completed!');
+    console.log(`📈 Summary:`);
+    console.log(`  - Sites processed: ${totalSitesProcessed}`);
+    console.log(`  - Total pages processed: ${totalPagesProcessed}`);
+    console.log(`  - Pages with scores: ${totalPagesWithScores}`);
+    console.log(`  - Success rate: ${Math.round((totalPagesWithScores / totalPagesProcessed) * 100)}%`);
+
+  } catch (error) {
+    console.error('❌ Error during score population:', error);
+    process.exit(1);
+  }
+}
+
+async function main() {
+  console.log('🔧 Populating initial cached scores for existing pages...');
+  console.log('This may take a while depending on the number of pages.\n');
+
+  // Confirm before proceeding
+  const args = process.argv.slice(2);
+  if (!args.includes('--confirm')) {
+    console.log('⚠️  This script will update all pages in the database.');
+    console.log('Add --confirm flag to proceed: npm run populate-scores -- --confirm');
+    process.exit(0);
+  }
+
+  await populateInitialScores();
+  
+  console.log('\n✅ Script completed successfully!');
+  process.exit(0);
+}
+
+// Handle graceful shutdown
+process.on('SIGINT', () => {
+  console.log('\n⚠️ Script interrupted by user');
+  process.exit(0);
+});
+
+process.on('SIGTERM', () => {
+  console.log('\n⚠️ Script terminated');
+  process.exit(0);
+});
+
+// Run the script
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('❌ Script failed:', error);
+    process.exit(1);
+  });
+}
+
+export { populateInitialScores };

--- a/backend/src/services/scoreUpdateService.ts
+++ b/backend/src/services/scoreUpdateService.ts
@@ -1,0 +1,261 @@
+import { db } from '../db/client';
+import { pages, sites } from '../db/schema';
+import { eq, sql } from 'drizzle-orm';
+import { EnhancedRatingService } from '../utils/enhancedRatingService';
+
+/**
+ * Service for managing cached page scores and site metrics
+ * This service updates page scores and propagates changes to site-level averages
+ */
+export class ScoreUpdateService {
+  
+  /**
+   * Update a page's cached score from its section ratings
+   * @param pageId - The ID of the page to update
+   * @returns The updated page score, or null if no section ratings found
+   */
+  static async updatePageScore(pageId: string): Promise<number | null> {
+    try {
+      // Get current section ratings
+      const sectionRatings = await EnhancedRatingService.getCurrentSectionRatings(pageId);
+      
+      if (!sectionRatings) {
+        console.log(`No section ratings found for page ${pageId}`);
+        return null;
+      }
+
+      // Calculate overall score from section ratings
+      const scores = Object.values(sectionRatings) as number[];
+      const total = scores.reduce((sum: number, score: number) => sum + score, 0);
+      const maxPossible = scores.length * 10; // 7 sections * 10 = 70
+      const pageScore = Math.round((total / maxPossible) * 100); // Convert to percentage
+
+      // Update the page's cached score
+      await db.update(pages)
+        .set({
+          pageScore,
+          lastScoreUpdate: new Date(),
+          updatedAt: new Date()
+        })
+        .where(eq(pages.id, pageId));
+
+      console.log(`✅ Updated page ${pageId} score to ${pageScore}%`);
+
+      // Get the page's site ID and update site metrics
+      const pageData = await db.select({ siteId: pages.siteId })
+        .from(pages)
+        .where(eq(pages.id, pageId))
+        .limit(1);
+
+      if (pageData.length > 0) {
+        await this.updateSiteMetrics(pageData[0].siteId);
+      }
+
+      return pageScore;
+    } catch (error) {
+      console.error(`❌ Failed to update page score for ${pageId}:`, error);
+      return null;
+    }
+  }
+
+  /**
+   * Update site-level cached metrics (average score, page counts)
+   * @param siteId - The ID of the site to update
+   */
+  static async updateSiteMetrics(siteId: string): Promise<void> {
+    try {
+      // Get all pages for this site with their scores
+      const sitePages = await db.select({
+        id: pages.id,
+        pageScore: pages.pageScore,
+        llmReadinessScore: pages.llmReadinessScore
+      })
+      .from(pages)
+      .where(eq(pages.siteId, siteId));
+
+      const totalPages = sitePages.length;
+      let totalScore = 0;
+      let pagesWithScores = 0;
+
+      // Calculate metrics from cached scores
+      for (const page of sitePages) {
+        // Use pageScore if available, fallback to llmReadinessScore
+        const score = page.pageScore ?? page.llmReadinessScore;
+        
+        if (score != null && score > 0) {
+          totalScore += score;
+          pagesWithScores++;
+        }
+      }
+
+      const averageLLMScore = pagesWithScores > 0 
+        ? Math.round(totalScore / pagesWithScores)
+        : 0;
+
+      // Update site's cached metrics
+      await db.update(sites)
+        .set({
+          averageLLMScore,
+          totalPages,
+          pagesWithScores,
+          lastMetricsUpdate: new Date(),
+          updatedAt: new Date()
+        })
+        .where(eq(sites.id, siteId));
+
+      console.log(`✅ Updated site ${siteId} metrics: ${averageLLMScore}% avg (${pagesWithScores}/${totalPages} pages)`);
+    } catch (error) {
+      console.error(`❌ Failed to update site metrics for ${siteId}:`, error);
+    }
+  }
+
+  /**
+   * Update scores for all pages in a site
+   * Useful for bulk updates or when migrating to the new system
+   * @param siteId - The ID of the site to update all pages for
+   */
+  static async updateAllPagesInSite(siteId: string): Promise<void> {
+    try {
+      const sitePages = await db.select({ id: pages.id })
+        .from(pages)
+        .where(eq(pages.siteId, siteId));
+
+      console.log(`🔄 Updating scores for ${sitePages.length} pages in site ${siteId}`);
+
+      for (const page of sitePages) {
+        await this.updatePageScore(page.id);
+      }
+
+      console.log(`✅ Completed updating all pages in site ${siteId}`);
+    } catch (error) {
+      console.error(`❌ Failed to update all pages in site ${siteId}:`, error);
+    }
+  }
+
+  /**
+   * Update scores for all pages across all sites
+   * Use with caution - this can be a long-running operation
+   */
+  static async updateAllScores(): Promise<void> {
+    try {
+      const allSites = await db.select({ id: sites.id, name: sites.name })
+        .from(sites)
+        .where(sql`${sites.deletedAt} IS NULL`);
+
+      console.log(`🔄 Starting bulk score update for ${allSites.length} sites`);
+
+      for (const site of allSites) {
+        console.log(`🔄 Processing site: ${site.name} (${site.id})`);
+        await this.updateAllPagesInSite(site.id);
+      }
+
+      console.log(`✅ Completed bulk score update for all sites`);
+    } catch (error) {
+      console.error(`❌ Failed to update all scores:`, error);
+    }
+  }
+
+  /**
+   * Get cached page score, fallback to calculation if not cached
+   * @param pageId - The ID of the page
+   * @returns The page score (0-100) or 0 if not available
+   */
+  static async getPageScore(pageId: string): Promise<number> {
+    try {
+      const pageData = await db.select({
+        pageScore: pages.pageScore,
+        llmReadinessScore: pages.llmReadinessScore
+      })
+      .from(pages)
+      .where(eq(pages.id, pageId))
+      .limit(1);
+
+      if (pageData.length === 0) {
+        return 0;
+      }
+
+      const page = pageData[0];
+
+      // Return cached score if available
+      if (page.pageScore != null) {
+        return page.pageScore;
+      }
+
+      // Fallback to legacy score
+      if (page.llmReadinessScore != null) {
+        return page.llmReadinessScore;
+      }
+
+      // Last resort: calculate and cache the score
+      const calculatedScore = await this.updatePageScore(pageId);
+      return calculatedScore ?? 0;
+    } catch (error) {
+      console.error(`❌ Failed to get page score for ${pageId}:`, error);
+      return 0;
+    }
+  }
+
+  /**
+   * Get cached site metrics
+   * @param siteId - The ID of the site
+   * @returns Site metrics object
+   */
+  static async getSiteMetrics(siteId: string): Promise<{
+    averageLLMScore: number;
+    totalPages: number;
+    pagesWithScores: number;
+  }> {
+    try {
+      const siteData = await db.select({
+        averageLLMScore: sites.averageLLMScore,
+        totalPages: sites.totalPages,
+        pagesWithScores: sites.pagesWithScores
+      })
+      .from(sites)
+      .where(eq(sites.id, siteId))
+      .limit(1);
+
+      if (siteData.length === 0) {
+        return { averageLLMScore: 0, totalPages: 0, pagesWithScores: 0 };
+      }
+
+      const site = siteData[0];
+
+      // If cached metrics are available, return them
+      if (site.averageLLMScore != null) {
+        return {
+          averageLLMScore: site.averageLLMScore,
+          totalPages: site.totalPages ?? 0,
+          pagesWithScores: site.pagesWithScores ?? 0
+        };
+      }
+
+      // If not cached, calculate and cache them
+      await this.updateSiteMetrics(siteId);
+      
+      // Fetch the updated metrics
+      const updatedSiteData = await db.select({
+        averageLLMScore: sites.averageLLMScore,
+        totalPages: sites.totalPages,
+        pagesWithScores: sites.pagesWithScores
+      })
+      .from(sites)
+      .where(eq(sites.id, siteId))
+      .limit(1);
+
+      if (updatedSiteData.length > 0) {
+        const updatedSite = updatedSiteData[0];
+        return {
+          averageLLMScore: updatedSite.averageLLMScore ?? 0,
+          totalPages: updatedSite.totalPages ?? 0,
+          pagesWithScores: updatedSite.pagesWithScores ?? 0
+        };
+      }
+
+      return { averageLLMScore: 0, totalPages: 0, pagesWithScores: 0 };
+    } catch (error) {
+      console.error(`❌ Failed to get site metrics for ${siteId}:`, error);
+      return { averageLLMScore: 0, totalPages: 0, pagesWithScores: 0 };
+    }
+  }
+}

--- a/backend/src/utils/analysisWorker.ts
+++ b/backend/src/utils/analysisWorker.ts
@@ -74,8 +74,7 @@ async function analyzePage(pageId: string) {
     // Use the new AnalysisService for comprehensive analysis
     console.log('🔍 About to call AnalysisService.analyzePage...');
     const analysisResult = await AnalysisService.analyzePage({
-      url: page.url,
-      contentSnapshot: page.contentSnapshot || undefined
+      url: page.url
     });
     console.log('✅ AnalysisService.analyzePage completed successfully');
 
@@ -221,3 +220,6 @@ analysisWorker.on('failed', (job, err) => {
 
 // Log when worker starts
 logger.info('🔄 Analysis worker started and ready to process jobs'); 
+
+// Export the analyzePage function for direct use
+export { analyzePage }; 

--- a/frontend/src/components/getting-started-checklist.tsx
+++ b/frontend/src/components/getting-started-checklist.tsx
@@ -12,7 +12,22 @@ interface GettingStartedChecklistProps {
   site: {
     trackerId?: string;
   } | null;
-  pages: Array<{ id: string; title?: string; url: string; llmReadinessScore?: number; lastScannedAt: string }>;
+  pages: Array<{ 
+    id: string; 
+    title?: string; 
+    url: string; 
+    llmReadinessScore?: number; 
+    lastScannedAt: string;
+    sectionRatings?: {
+      title: number;
+      description: number;
+      headings: number;
+      content: number;
+      schema: number;
+      images: number;
+      links: number;
+    };
+  }>;
   recentlyScanned: number;
   onShowTrackerScript: () => void;
   onShowPageManagement: () => void;


### PR DESCRIPTION
- Added `populate-scores` script to initialize cached scores for existing pages.
- Introduced `ScoreUpdateService` for managing page scores and site-level metrics.
- Updated database schema to include new fields for page and site metrics.
- Enhanced analysis and page handling logic to utilize new scoring system.
- Refactored frontend components to display updated metrics and scores.
- Improved overall score calculation by integrating section ratings into the scoring logic.